### PR TITLE
Prepare for PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.pyc
 build
 dist
-augment.egg-info
+augment_nd.egg-info

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019 Jan Funke
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A simple elastic augmentation for ND arrays.
 
 # Installation
 
-`python setup.py install`
+`pip install augment-nd`
 
 # Usage
 

--- a/augment/__init__.py
+++ b/augment/__init__.py
@@ -1,2 +1,6 @@
 from .transform import create_identity_transformation, create_rotation_transformation, create_elastic_transformation, apply_transformation, upscale_transformation
 from .augment import augment_all
+
+__version__ = '0.1.1'
+__version_info__ = tuple(int(i)for i in __version__.split('.'))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 numpy
 scipy
 h5py
+twine>=1.13.0
+wheel>=0.33.1
+setuptools>=40.8.0
+

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,25 @@
 from setuptools import setup
 
+with open('README.md') as f:
+    long_description = f.read()
+
 setup(
-        name='augment',
-        version='0.1',
+        name='augment-nd',
+        version='0.1.1',
         description='Simple elastic augmentation for ND arrays.',
         url='https://github.com/funkey/augment',
         author='Jan Funke',
         author_email='jfunke@iri.upc.edu',
         license='MIT',
         packages=['augment'],
+        long_description=long_description,
+        long_description_content_type='text/markdown',
+        install_requires=['h5py', 'numpy', 'scipy'],
+        classifiers=[
+            "Programming Language :: Python :: 2",
+            "Programming Language :: Python :: 3",
+            "License :: OSI Approved :: MIT License",
+            "Operating System :: OS Independent",
+        ]
 )
+


### PR DESCRIPTION
Reducing activation energy for resolving #1 

If merged, I think all you'd need to do is `python setup.py sdist bdist_wheel` and `twine upload dist/` (possibly with a minor amount of environment and credential-wrangling).

I picked `augment-nd` as the name under which it would appear on PyPI but don't have strong opinions on it. It would still be imported as `augment`.