### PR TITLE
More rotations

### DIFF
--- a/augment/transform.py
+++ b/augment/transform.py
@@ -88,6 +88,45 @@ def create_rotation_transformation(shape, angle, subsample=1, axes=None):
         control_point_offsets[(slice(None),) + control_point] += displacement
 
     return upscale_transformation(control_point_offsets, subsample_shape)
+    
+def create_3D_rotation_transformation(shape, rotation, subsample=1, axes=None):
+    """
+    rotation: `Scipy.spatial.transform.Rotation` instance
+    axes: boolean array-like with length equal to shape. Must sum to 3.
+        By default uses the last 3 dimensions.
+    """
+    if axes is None:
+        axes = np.array((False,)*(len(shape)-3) + (True,)*3)
+    else:
+        axes = np.array(axes, dtype=bool)
+        assert axes.sum() == 3, f"Cannot perform 3D rotation on {axes.sum()} axes"
+
+
+    dims = len(shape)
+    subsample_shape = tuple(max(1,int(s/subsample)) for s in shape)
+    control_points = (2,)*dims
+
+    # map control points to world coordinates
+    control_point_scaling_factor = tuple(float(s-1) for s in shape)
+
+    # rotate control points
+    center = np.array([0.5*(d-1) for d in shape])
+
+    # print("Creating rotation transformation with:")
+    # print("\tangle : " + str(angle))
+    # print("\tcenter: " + str(center))
+
+    control_point_offsets = np.zeros((dims,) + control_points, dtype=np.float32)
+    for control_point in np.ndindex(control_points):
+
+        point = np.array(control_point)*control_point_scaling_factor
+        center_offset = np.array([p-c for c,p in zip(center, point)], dtype=np.float32)
+        rotated_offset = np.array(center_offset)
+        rotated_offset[axes] = rotation.apply(center_offset[axes])
+        displacement = rotated_offset - center_offset
+        control_point_offsets[(slice(None),) + control_point] += displacement
+
+    return upscale_transformation(control_point_offsets, subsample_shape)
 
 def create_elastic_transformation(shape, control_point_spacing = 100, jitter_sigma = 10.0, subsample = 1):
 

--- a/augment/transform.py
+++ b/augment/transform.py
@@ -56,7 +56,12 @@ def create_identity_transformation(shape, subsample=1, scale=1.0):
 
     return transformation
 
-def create_rotation_transformation(shape, angle, subsample=1):
+def create_rotation_transformation(shape, angle, subsample=1, axes=None):
+    if axes is None:
+        axes = np.array((False,)*(len(shape)-2) + (True,)*2)
+    else:
+        axes = np.array(axes, dtype=bool)
+
 
     dims = len(shape)
     subsample_shape = tuple(max(1,int(s/subsample)) for s in shape)
@@ -78,7 +83,7 @@ def create_rotation_transformation(shape, angle, subsample=1):
         point = np.array(control_point)*control_point_scaling_factor
         center_offset = np.array([p-c for c,p in zip(center, point)], dtype=np.float32)
         rotated_offset = np.array(center_offset)
-        rotated_offset[-2:] = rotate(center_offset[-2:], angle)
+        rotated_offset[axes] = rotate(center_offset[axes], angle)
         displacement = rotated_offset - center_offset
         control_point_offsets[(slice(None),) + control_point] += displacement
 


### PR DESCRIPTION
Allow user specified axes for 2D rotations
Allow 3D rotations

Screenshot of available rotations (orange: previously supported 2D rotation, green: new 2D rotation axes, blue: 3D rotations):
![Screenshot from 2022-04-04 08-26-32](https://user-images.githubusercontent.com/14844826/161581046-93e04cf6-bc45-4cfc-b000-3c1be20fc3d1.png)


A script to generate new rotations:
```python
import numpy as np
import matplotlib.pyplot as plt
from scipy.spatial.transform import Rotation

import augment

import math
import random

from augment.transform import rotate


data = np.zeros((21, 21, 21))
data[10, 10, 5] = 1

indentity_transform = augment.create_identity_transformation(data.shape)

points = []
points_2d_default = []
points_2d_z_axis = []
points_3d = []

for i in range(500):
    rotation = indentity_transform + augment.create_rotation_transformation(
        data.shape, random.random() * math.pi * 2
    )
    rotated_data = augment.apply_transformation(data, rotation)
    ind = (
        np.array(
            np.unravel_index(np.argmax(rotated_data, axis=None), rotated_data.shape)
        )
        / 50
    ) - 1
    points_2d_default.append(ind)

for i in range(500):
    rotation = indentity_transform + augment.create_rotation_transformation(
        data.shape, random.random() * math.pi * 2, axes=(1, 0, 1)
    )
    rotated_data = augment.apply_transformation(data, rotation)
    ind = (
        np.array(
            np.unravel_index(np.argmax(rotated_data, axis=None), rotated_data.shape)
        )
        / 50
    ) - 1
    points_2d_z_axis.append(ind)

for i in range(500):
    rotation = indentity_transform + augment.create_3D_rotation_transformation(
        data.shape, Rotation.random(), axes=(1, 1, 1)
    )
    rotated_data = augment.apply_transformation(data, rotation)
    ind = (
        np.array(
            np.unravel_index(np.argmax(rotated_data, axis=None), rotated_data.shape)
        )
        / 50
    ) - 1
    points_3d.append(ind)

points.extend([points_2d_default, points_2d_z_axis, points_3d])

fig = plt.figure(figsize=(7, 7))
ax = plt.axes(projection="3d")

for point_set in points[::-1]:
    x, y, z = zip(*point_set)

    # Create Plot

    ax.scatter3D(x, y, z)

# Show plot

plt.show()
```